### PR TITLE
Add limit in how many configurations each user may have.

### DIFF
--- a/server.go
+++ b/server.go
@@ -595,7 +595,7 @@ func (s *Server) CreateClient(w http.ResponseWriter, r *http.Request, ps httprou
 
 	if *maxNumberClientConfig > 0 {
 		if len(c.Clients) >= *maxNumberClientConfig {
-			log.Error(fmt.Errorf("user %s have to many configs", c.Name))
+			log.Error(fmt.Errorf("user %q have too many configs", c.Name))
 			w.WriteHeader(http.StatusTooManyRequests)
 			return
 		}

--- a/server.go
+++ b/server.go
@@ -596,7 +596,21 @@ func (s *Server) CreateClient(w http.ResponseWriter, r *http.Request, ps httprou
 	if *maxNumberClientConfig > 0 {
 		if len(c.Clients) >= *maxNumberClientConfig {
 			log.Error(fmt.Errorf("user %q have too many configs", c.Name))
+
+			e := struct {
+				Error string
+			}{
+				Error: "Max number of configs: " + strconv.Itoa(*maxNumberClientConfig),
+			}
+
+			j, err := json.Marshal(e)
+			if err != nil {
+				log.Error(err)
+				return
+			}
+
 			w.WriteHeader(http.StatusTooManyRequests)
+			fmt.Fprintf(w, string(j))
 			return
 		}
 	}

--- a/server.go
+++ b/server.go
@@ -33,11 +33,12 @@ import (
 var (
 	dataDir = kingpin.Flag("data-dir", "Directory used for storage").Default("/var/lib/wireguard-ui").String()
 
-	listenAddr     = kingpin.Flag("listen-address", "Address to listen to").Default(":8080").String()
-	natEnabled     = kingpin.Flag("nat", "Whether NAT is enabled or not").Default("true").Bool()
-	natLink        = kingpin.Flag("nat-device", "Network interface to masquerade").Default("wlp2s0").String()
-	clientIPRange  = kingpin.Flag("client-ip-range", "Client IP CIDR").Default("172.31.255.0/24").String()
-	authUserHeader = kingpin.Flag("auth-user-header", "Header containing username").Default("X-Forwarded-User").String()
+	listenAddr            = kingpin.Flag("listen-address", "Address to listen to").Default(":8080").String()
+	natEnabled            = kingpin.Flag("nat", "Whether NAT is enabled or not").Default("true").Bool()
+	natLink               = kingpin.Flag("nat-device", "Network interface to masquerade").Default("wlp2s0").String()
+	clientIPRange         = kingpin.Flag("client-ip-range", "Client IP CIDR").Default("172.31.255.0/24").String()
+	authUserHeader        = kingpin.Flag("auth-user-header", "Header containing username").Default("X-Forwarded-User").String()
+	maxNumberClientConfig = kingpin.Flag("max-number-client-config", "Max number of configs an client can use. 0 is unlimited").Default("0").Int()
 
 	wgLinkName   = kingpin.Flag("wg-device-name", "WireGuard network device name").Default("wg0").String()
 	wgListenPort = kingpin.Flag("wg-listen-port", "WireGuard UDP port to listen to").Default("51820").Int()
@@ -591,6 +592,14 @@ func (s *Server) CreateClient(w http.ResponseWriter, r *http.Request, ps httprou
 
 	c := s.Config.GetUserConfig(user)
 	log.Debugf("user config: %#v", c)
+
+	if *maxNumberClientConfig > 0 {
+		if len(c.Clients) >= *maxNumberClientConfig {
+			log.Error(fmt.Errorf("user %s have to many configs", c.Name))
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+	}
 
 	i := 0
 	for k := range c.Clients {

--- a/server.go
+++ b/server.go
@@ -609,7 +609,7 @@ func (s *Server) CreateClient(w http.ResponseWriter, r *http.Request, ps httprou
 				return
 			}
 
-			w.WriteHeader(http.StatusTooManyRequests)
+			w.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(w, string(j))
 			return
 		}

--- a/ui/src/Clients.svelte
+++ b/ui/src/Clients.svelte
@@ -17,11 +17,21 @@
   async function handleNewClick(event) {
     const res = await fetch(clientsUrl, {
       method: "POST",
-    });
-    let newClient = await res.json();
-    console.log("New client added", newClient);
+    })
+      .then(response => {
+        return response.json()
+    })
+    .then(data => {
+      if (typeof data.Error != "undefined") {
+          console.log(data.Error);
+          alert(data.Error);
+    } else {
+        console.log("New client added", data);
+    }
+  });
     await getClients();
   }
+
 
 	onMount(getClients);
 </script>


### PR DESCRIPTION
If the option max-number-client-config is more than 0 this number is the
maximum number of clients a user can create.

The setting only limits creation. If a user had created more
configurations before this setting is enforced or lowered the user may
user the service as before, just cant create any more configurations.


This partitionaly fixes #46 . I have tested the function that it works, but it does not notifies the user what the source of the problem is. I'm not familiar with node or svelte, but I have looked at:
 https://github.com/keenethics/svelte-notifications
and that might be used as notification framework.
But I think this must be a discussion with the maintainers of their long time goal for the project.

Also the http status code I choose as an response might be discussed: 429.


Added 2020-03-19: This PR now includes an alert() when the user tried to create more than the limit.
Added 2020-03-20: Use http status 400 instead of 429 as discussed.