### PR TITLE
Disable cgo

### DIFF
--- a/.github/workflows/push_master.yaml
+++ b/.github/workflows/push_master.yaml
@@ -66,7 +66,7 @@ jobs:
         target=linux-amd64
         release_name="$name-$tag-$target"
         release_tar="$release_name.tar.gz"
-        go build -o "$release_name"
+        env CGO_ENABLED=0 go build -o "$release_name"
         tar czvf "$release_tar" "$release_name"
         echo -n "$(shasum -ba 256 "${release_tar}" | cut -d " " -f 1)" > "${release_tar}.sha256"
         rm "$release_name"
@@ -78,7 +78,7 @@ jobs:
         target=linux-armv5
         release_name="$name-$tag-$target"
         release_tar="$release_name.tar.gz"
-        env GOOS=linux GOARCH=arm GOARM=5 go build -o "$release_name"
+        env CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=5 go build -o "$release_name"
         tar czvf "$release_tar" "$release_name"
         echo -n "$(shasum -ba 256 "${release_tar}" | cut -d " " -f 1)" > "${release_tar}.sha256"
         rm "$release_name"
@@ -90,7 +90,7 @@ jobs:
         target=linux-armv6
         release_name="$name-$tag-$target"
         release_tar="$release_name.tar.gz"
-        env GOOS=linux GOARCH=arm GOARM=6 go build -o "$release_name"
+        env CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -o "$release_name"
         tar czvf "$release_tar" "$release_name"
         echo -n "$(shasum -ba 256 "${release_tar}" | cut -d " " -f 1)" > "${release_tar}.sha256"
         rm "$release_name"
@@ -102,7 +102,7 @@ jobs:
         target=linux-armv7
         release_name="$name-$tag-$target"
         release_tar="$release_name.tar.gz"
-        env GOOS=linux GOARCH=arm GOARM=7 go build -o "$release_name"
+        env CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -o "$release_name"
         tar czvf "$release_tar" "$release_name"
         echo -n "$(shasum -ba 256 "${release_tar}" | cut -d " " -f 1)" > "${release_tar}.sha256"
         rm "$release_name"


### PR DESCRIPTION
This allows to run binaries without being dependant on glibc in a cases when it is not available, like busybox or alpine docker image.

```
# go build
# ldd wireguard-ui
	linux-vdso.so.1 (0x00007ffdef2f3000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f3daf66a000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f3daf478000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f3daf691000)


# CGO_ENABLED=0 go build
# ldd wireguard-ui
	not a dynamic executable
```