### PR TITLE
Use Debian variant of node in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/node:12-alpine AS ui
+FROM docker.io/node:12 AS ui
 WORKDIR /ui
 COPY ui/package.json ui/package-lock.json /ui/
 RUN npm install


### PR DESCRIPTION
Change build image to node:12 instead of node:12-alpine due to Sass build failures triggered by missing Python 2 on platforms that require Sass build.

Also has no impact on final image size as build layers are discarded in final image using distroless.

Fixes #75 