### PR TITLE
Adding support for PersistentKeepalive in user configs

### DIFF
--- a/server.go
+++ b/server.go
@@ -464,9 +464,9 @@ func (s *Server) GetClient(w http.ResponseWriter, r *http.Request, ps httprouter
 		dns = fmt.Sprint("DNS = ", *wgDNS)
 	}
 
-	keepalive := ""
+	keepAlive := ""
 	if *wgKeepAlive != "" {
-		keepalive = fmt.Sprint("PersistentKeepalive = ", *wgKeepAlive)
+		keepAlive = fmt.Sprint("PersistentKeepalive = ", *wgKeepAlive)
 	}
 
 	configData := fmt.Sprintf(`[Interface]
@@ -479,7 +479,7 @@ PublicKey = %s
 AllowedIPs = %s
 Endpoint = %s
 %s
-`, client.IP.String(), client.PrivateKey, dns, s.Config.PublicKey, allowedIPs, *wgEndpoint, keepalive)
+`, client.IP.String(), client.PrivateKey, dns, s.Config.PublicKey, allowedIPs, *wgEndpoint, keepAlive)
 
 	format := r.URL.Query().Get("format")
 


### PR DESCRIPTION
This small change adds support for PresistentKeepalive which is a feature in WireGuard. 
You can read more about PresistentKeepalive in WireGuards documentation found [here](https://www.wireguard.com/quickstart/).

This value is by default unset like DNS, but once specified in startup with `--wg-keepalive` it will be included under `[peer]` in the configs distributed to users. The value is set in seconds and WireGuard per default has set this to `0`.