### PR TITLE
Diffing of configuration data

### DIFF
--- a/server.go
+++ b/server.go
@@ -275,6 +275,14 @@ func (s *Server) configureWireGuard() error {
 		return err
 	}
 
+	log.Debugf("Getting current Wireguard config")
+	currentdev, err := wg.Device(*wgLinkName)
+	if err != nil {
+		return err
+	}
+	currentpeers := currentdev.Peers
+	diffpeers := make([]wgtypes.PeerConfig, 0);
+
 	peers := make([]wgtypes.PeerConfig, 0)
 	for user, cfg := range s.Config.Users {
 		for id, dev := range cfg.Clients {
@@ -297,11 +305,46 @@ func (s *Server) configureWireGuard() error {
 		}
 	}
 
+	// Determine peers updated and to be removed from WireGuard
+	for _, i := range currentpeers{
+		found := false
+		for _, j := range peers{
+			if (i.PublicKey == j.PublicKey){
+				found = true
+				j.UpdateOnly = true
+				diffpeers = append(diffpeers, j)
+				break
+			}
+		}
+		if (!found){
+			peertoremove :=  wgtypes.PeerConfig{
+				PublicKey : i.PublicKey,
+				Remove : true,
+			}
+			diffpeers = append(diffpeers, peertoremove)
+		}
+	}
+
+	// Determine peers to be added to WireGuard
+	for _, i := range peers{
+		found := false
+		for _, j := range currentpeers{
+			if (i.PublicKey == j.PublicKey){
+				found = true
+				break
+			}
+		}
+		if (!found){
+			diffpeers = append(diffpeers, i)
+		}
+	}
+
+
 	cfg := wgtypes.Config{
 		PrivateKey:   &key,
 		ListenPort:   wgListenPort,
-		ReplacePeers: true,
-		Peers:        peers,
+		ReplacePeers: false,
+		Peers:        diffpeers,
 	}
 	err = wg.ConfigureDevice(*wgLinkName, cfg)
 	if err != nil {


### PR DESCRIPTION
These changes will prevent a full reload of the Wireguard interface (due to `ReplacePeers: true`) as that breaks active VPN sessions. The improvement is achieved by using the `UpdateOnly` and `Removed` attributes of `wgtypes.PeerConfig`
flags to manage peers.

The breaking of sessions can be tested with ssh while connected to the VPN. The current main branch will cause the ssh session to lag or close while WireGuard handshakes the connection. With the changes no new handshake takes places as connections are persevered.