### PR TITLE
Support for wireguard device name configuration in wg-ui userspace

### DIFF
--- a/docker-compose.userspace.yml
+++ b/docker-compose.userspace.yml
@@ -3,7 +3,6 @@ version: "3.7"
 services:
   app:
     image: embarkstudios/wireguard-ui:userspace
-    entrypoint: "/wg-go-ui"
     privileged: true
     network_mode: "host"
     volumes:
@@ -13,8 +12,8 @@ services:
       - WIREGUARD_UI_LOG_LEVEL=debug
       - WIREGUARD_UI_DATA_DIR=/data
       - WIREGUARD_UI_WG_ENDPOINT=your-andpoint-address:51820
-      - WIREGUARD_UI_CLIENT_IP_RANGE=192.168.10.0/24
-     # - WIREGUARD_UI_WG_DNS=192.168.10.0
+      - WIREGUARD_UI_CLIENT_IP_RANGE=192.168.10.1/24
+     # - WIREGUARD_UI_WG_DNS=192.168.10.1
       - WIREGUARD_UI_NAT=true
       - WIREGUARD_UI_NAT_DEVICE=eth0
      # - WIREGUARD_UI_WG_DEVICE_NAME=wg1

--- a/docker-compose.userspace.yml
+++ b/docker-compose.userspace.yml
@@ -2,8 +2,8 @@ version: "3.7"
 
 services:
   app:
-    image: embarkstudios/wireguard-ui:latest
-    entrypoint: "/wireguard-ui"
+    image: embarkstudios/wireguard-ui:userspace
+    entrypoint: "/wg-go-ui"
     privileged: true
     network_mode: "host"
     volumes:
@@ -17,6 +17,6 @@ services:
      # - WIREGUARD_UI_WG_DNS=192.168.10.0
       - WIREGUARD_UI_NAT=true
       - WIREGUARD_UI_NAT_DEVICE=eth0
-     # - WIREGUARD_UI_WG_DEVICE_NAME=wg0
+     # - WIREGUARD_UI_WG_DEVICE_NAME=wg1
 
     restart: always

--- a/wg-go-ui.sh
+++ b/wg-go-ui.sh
@@ -8,7 +8,7 @@ TUNFILE=/dev/net/tun
 [ ! -c $TUNFILE ] && mknod $TUNFILE c 10 200
 
 # Start the first process
-./wireguard-go wg0
+./wireguard-go ${WIREGUARD_UI_WG_DEVICE_NAME:-wg0}
 status=$?
 if [ $status -ne 0 ]; then
   echo "Failed to start wireguard-go: $status"


### PR DESCRIPTION
This feature adds the support to configure the wireguard device name in the wg-ui userspace build. This configuration should already work in the wg-ui:latest build using the kernel version of wireguard (see [server.go](https://github.com/EmbarkStudios/wg-ui/blob/40d40d05542d432a30d65d97542a9345ab466e89/server.go#L45)) and was therefore not tested here.

The main change was done in [wg-go-ui.sh](https://github.com/phil535/wg-ui/blob/75aa4a89191209b19827c4bbe736b3350e50842d/wg-go-ui.sh#L11) parsing the environmental variable `WIREGUARD_UI_WG_DEVICE_NAME`. The default value is still `wg0`.

In addition to this change a docker-compose file for userspace was added. This docker-compose file is just a copy of the kernel version with some minor adjustments.

The build process as well as the docker execution was tested with the device name wg1 in userspace mode and works as expected.

I think it would be better to not list the environmental variable `WIREGUARD_UI_WG_DEVICE_NAME` in the docker-compose files at all and add a parameter description in the configuration section of the readme.