### PR TITLE
revert back to wireguard-ui

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/embarkstudios/wg-ui
+module github.com/embarkstudios/wireguard-ui
 
 go 1.17
 


### PR DESCRIPTION
Since using wg-ui breaks stuff, will revert back and do a better rename later.