### PR TITLE
Remove usage of port 5555 in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Current stable release: [v1.3.0](https://github.com/EmbarkStudios/wg-ui/releases
 
 The easiest way to run wg-ui is using the container image. To test it, run:
 
-```docker run --rm -it --privileged --entrypoint "/wireguard-ui" -v /tmp/wireguard-ui:/data -p 8080:8080 -p 5555:5555 embarkstudios/wireguard-ui:latest --data-dir=/data --log-level=debug```
+```docker run --rm -it --privileged --entrypoint "/wireguard-ui" -v /tmp/wireguard-ui:/data -p 8080:8080 embarkstudios/wireguard-ui:latest --data-dir=/data --log-level=debug```
 
 When running in production, we recommend using the latest release as opposed to `latest`.
 


### PR DESCRIPTION
Can't find any relationship to port 5555 in current code, therefore removing it from documentation.

Thank you @alvarlagerlof for pointing this out, fixes #151 