### PR TITLE
Add wireguard server MTU configuration

### DIFF
--- a/server.go
+++ b/server.go
@@ -51,6 +51,7 @@ var (
 	wgAllowedIPs = kingpin.Flag("wg-allowed-ips", "WireGuard client allowed ips").Default("0.0.0.0/0").Strings()
 	wgDNS        = kingpin.Flag("wg-dns", "WireGuard client DNS server (optional)").Default("").String()
 	wgKeepAlive  = kingpin.Flag("wg-keepalive", "WireGuard Keepalive for peers, defined in seconds (optional)").Default("").String()
+	wgServerMtu  = kingpin.Flag("wg-server-mtu", "WireGuard server MTU").Default("1420").Int()
 
 	devUIServer = kingpin.Flag("dev-ui-server", "Developer mode: If specified, proxy all static assets to this endpoint").String()
 
@@ -170,6 +171,13 @@ func (s *Server) initInterface() error {
 	if os.IsExist(err) {
 		log.Infof("WireGuard interface %s already has the requested address: ", s.clientIPRange)
 	} else if err != nil {
+		return err
+	}
+
+	log.Debug("Setting link MTU: ", *wgServerMtu)
+	err = netlink.LinkSetMTU(&link, *wgServerMtu)
+	if err != nil {
+		log.Error("Error setting link MTU: ", *wgLinkName)
 		return err
 	}
 


### PR DESCRIPTION
This feature adds the ability to configure the MTU of your wireguard link device using the default kingpin flags (ENV vars & CLI args).

The MTU is set during wireguard interface initialisation.

The feature was tested locally and successfully builds using docker. 


This feature is acts as counterpart to the [client MTU configuration pull request](https://github.com/EmbarkStudios/wg-ui/pull/184).
