### PR TITLE
Add wireguard client default MTU configuration

### DIFF
--- a/server.go
+++ b/server.go
@@ -55,7 +55,7 @@ var (
 	wgAllowedIPs = kingpin.Flag("wg-allowed-ips", "WireGuard client allowed ips").Default("0.0.0.0/0").Strings()
 	wgDNS        = kingpin.Flag("wg-dns", "WireGuard client DNS server (optional)").Default("").String()
 	wgKeepAlive  = kingpin.Flag("wg-keepalive", "WireGuard Keepalive for peers, defined in seconds (optional)").Default("").String()
-  wgServerMtu  = kingpin.Flag("wg-server-mtu", "WireGuard server MTU").Default("1420").Int()
+	wgServerMtu  = kingpin.Flag("wg-server-mtu", "WireGuard server MTU").Default("1420").Int()
 	wgPeerMtu    = kingpin.Flag("wg-peer-mtu", "WireGuard default peer MTU").Default(strconv.Itoa(wgDefaultMtu)).Int()
 
 	devUIServer = kingpin.Flag("dev-ui-server", "Developer mode: If specified, proxy all static assets to this endpoint").String()


### PR DESCRIPTION
This feature adds the ability to configure the default MTU of your wireguard client configurations using the default kingpin flags (ENV vars & CLI args).

Client MTU configuration was also implemented in the web API but not in the web UI.

A new MTU field was introduces in the ClientConfiguration struct.

The migration of old ServerConfiguration gets executed at startup and works as follows:
If any client MTU has the value 0 (uninitialized default value), the client MTU get set to the MTU value introduced in this feature.
If this MTU value of this feature is invalid, the client MTU gets set to 1420.
If any MTU value was changed, the server configuration is saved.

The MTU entry in the wireguard client configuration (download/QR code) only gets added if the client configuration has a value different from 1420.

The feature was tested locally and successfully builds using docker. 

This feature is acts as counterpart to the [server MTU configuration pull request](https://github.com/EmbarkStudios/wg-ui/pull/183).